### PR TITLE
Changes to support Gpsd 11 on ubuntu 22.04

### DIFF
--- a/tasks/GPSDTask.cpp
+++ b/tasks/GPSDTask.cpp
@@ -110,6 +110,13 @@ gps_base::GPS_SOLUTION_TYPES gpsdFixPositionType(gps_data_t const& gpsd) {
 }
 #else
 gps_base::GPS_SOLUTION_TYPES gpsdFixPositionType(gps_data_t const& gpsd) {
+  switch(gpsd.fix.mode) {
+    case MODE_NO_FIX:
+      return gps_base::NO_SOLUTION;
+    case MODE_2D:
+      return gps_base::AUTONOMOUS_2D;
+  }
+
   auto status = gpsdFixStatus(gpsd);
   switch(status)
   {
@@ -117,11 +124,7 @@ gps_base::GPS_SOLUTION_TYPES gpsdFixPositionType(gps_data_t const& gpsd) {
     return gps_base::NO_SOLUTION;
 
   case STATUS_FIX:
-    if(gpsd.fix.mode == MODE_2D){
-      return gps_base::AUTONOMOUS_2D;
-    } else {
-      return gps_base::AUTONOMOUS;
-    }
+    return gps_base::AUTONOMOUS;
   case STATUS_DGPS_FIX:
     return gps_base::DIFFERENTIAL;
 

--- a/tasks/GPSDTask.cpp
+++ b/tasks/GPSDTask.cpp
@@ -79,7 +79,7 @@ double gpsdFixGeoidalSeparation(gps_data_t const& gpsd) {
 #endif
 }
 
-#if GPSD_API_MAJOR_VERSION >= 10
+#if GPSD_API_MAJOR_VERSION >= 12
 gps_base::GPS_SOLUTION_TYPES gpsdFixPositionType(gps_data_t const& gpsd) {
   switch(gpsd.fix.mode) {
     case MODE_NO_FIX:


### PR DESCRIPTION
This came up in our CI after the merge of https://github.com/rock-drivers/drivers-orogen-gps/pull/7. @doudou i can remove the backport bit, but some form of that should be included, possibly gated on the change in api that warrants the change in our code.